### PR TITLE
fix - to train on CPU, make sure to call contiguous() on x and y before reshaping

### DIFF
--- a/scripts/test_pretrained_model.py
+++ b/scripts/test_pretrained_model.py
@@ -50,7 +50,7 @@ def test(test_dataset, model, best_of_n = 1):
 			y = traj[:, hyper_params["past_length"]:, :]
 			y = y.cpu().numpy()
 			# reshape the data
-			x = x.view(-1, x.shape[1]*x.shape[2])
+			x = x.contiguous().view(-1, x.shape[1]*x.shape[2])
 			x = x.to(device)
 
 			future = y[:, :-1, :]

--- a/scripts/training_loop.py
+++ b/scripts/training_loop.py
@@ -48,10 +48,10 @@ def train(train_dataset):
 		x = traj[:, :hyper_params['past_length'], :]
 		y = traj[:, hyper_params['past_length']:, :]
 
-		x = x.view(-1, x.shape[1]*x.shape[2]) # (x,y,x,y ... )
+		x = x.contiguous().view(-1, x.shape[1]*x.shape[2]) # (x,y,x,y ... )
 		x = x.to(device)
 		dest = y[:, -1, :].to(device)
-		future = y[:, :-1, :].view(y.size(0),-1).to(device)
+		future = y[:, :-1, :].contiguous().view(y.size(0),-1).to(device)
 
 		dest_recon, mu, var, interpolated_future = model.forward(x, initial_pos, dest=dest, mask=mask, device=device)
 


### PR DESCRIPTION
When training on CPU (i.e. no cuda) I got the following error -

```
$ python training_loop.py                                            
cpu
{'adl_reg': 1, 'data_scale': 1.86, 'dataset_type': 'image', 'dec_size': [1024, 512, 1024], 'dist_thresh': 100, 'enc_dest_size': [8, 16], 'enc_latent_size': [8, 50], 'enc_past_size': [512, 256], 'non_local_theta_size': [256, 128, 64], 'non_local_phi_size': [256, 128, 64], 'non_local_g_size': [256, 128, 64], 'non_local_dim': 128, 'fdim': 16, 'future_length': 12, 'gpu_index': 0, 'kld_reg': 1, 'learning_rate': 0.0003, 'mu': 0, 'n_values': 20, 'nonlocal_pools': 3, 'normalize_type': 'shift_origin', 'num_epochs': 650, 'num_workers': 0, 'past_length': 8, 'predictor_hidden_size': [1024, 512, 256], 'sigma': 1.3, 'test_b_size': 4096, 'time_thresh': 0, 'train_b_size': 512, 'zdim': 16}
../social_pool_data/train_all_512_0_100.pickle
/Users/ksachdeva/Desktop/Dev/myoss/PECNet/utils/social_utils.py:211: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
  traj_new = np.array(traj_new)
/Users/ksachdeva/Desktop/Dev/myoss/PECNet/utils/social_utils.py:212: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
  masks_new = np.array(masks_new)
/Users/ksachdeva/Desktop/Dev/myoss/PECNet/utils/social_utils.py:215: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
  self.initial_pos_batches = np.array(initial_pos(self.trajectory_batches)) #for relative positioning
../social_pool_data/test_all_4096_0_100.pickle
Traceback (most recent call last):
  File "training_loop.py", line 157, in <module>
    train_loss, rcl, kld, adl = train(train_dataset)
  File "training_loop.py", line 51, in train
    x = x.view(-1, x.shape[1]*x.shape[2]) # (x,y,x,y ... )
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```

This is a known issue. See https://github.com/agrimgupta92/sgan/issues/22

I have opted to use `contiguous` instead of `reshape`. 

Surprisingly the issue is not present when I run `test_pretrained_mode` but I have added `contiguous` just to be consistent.


